### PR TITLE
Fix clearing of interest period inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,6 +844,8 @@
     // bind events
     document.getElementById('addRate').addEventListener('click', function(e){
       e.preventDefault();
+      // preserva valores actuales antes de agregar una fila nueva
+      rateRows = readRates();
       rateRows.push({start: (document.getElementById('startDate').value||''), end: null, annual:null});
       renderRates();
     });
@@ -851,6 +853,8 @@
     ratesBox.addEventListener('click', function(e){
       var del = e.target && e.target.getAttribute('data-del');
       if (del!==null && del!==undefined){
+        // sincroniza valores editados antes de eliminar
+        rateRows = readRates();
         var idx = Number(del);
         if (idx>0){ rateRows.splice(idx,1); renderRates(); }
       }


### PR DESCRIPTION
## Summary
- Preserve existing rate inputs before adding a new interest period
- Sync current rate values when removing a period to avoid losing edits

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc91ddb6c83318997ced47b890233