### PR TITLE
Avoid duplicated extra payment on due date

### DIFF
--- a/calc-hip/index.html
+++ b/calc-hip/index.html
@@ -318,7 +318,7 @@
       var ev = extraEvents[i]; if (!ev) continue;
       var d = (ev.date instanceof Date)? ev.date : fromISO(ev.date);
       var a = Number(ev.amount)||0;
-      if (a>0 && d>=prev && d<=due) list.push({date:d, amount:a});
+      if (a>0 && d>prev && d<=due) list.push({date:d, amount:a});
     }
     // Recurrente mensual
     var m = monthlies(prev,due,recurCfg);


### PR DESCRIPTION
## Summary
- prevent first extra contribution from being counted twice by ignoring events on the previous period boundary

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bdd4d14b6c83318a47e2436d2d8fc2